### PR TITLE
ACF compatibility

### DIFF
--- a/com/blayter/logging/appenders/BugLogHQAppender.cfc
+++ b/com/blayter/logging/appenders/BugLogHQAppender.cfc
@@ -31,8 +31,13 @@ component extends="coldbox.system.logging.AbstractAppender" output="false" hint=
 				}	
 			if(NOT isDefined("arguments.exception.transactionId"))
 				{
-				arguments.exception.transactionId = createGuid();
-				transactionId = arguments.exception.transactionId;
+					if(findNocase(server.coldfusion.productname,'lucee')){
+						arguments.exception.transactionId = createGuid();
+					}
+					else{
+						arguments.exception.transactionId = createUuid();
+					}
+					transactionId = arguments.exception.transactionId;
 				}
 			else
 				{


### PR DESCRIPTION
createGUID is only supported by Lucee, added check for versionname
if Lucee, then use createGUID, else use createUUID